### PR TITLE
Add script to check merged PRs with "needs backport to 3.x"

### DIFF
--- a/needs_backport.py
+++ b/needs_backport.py
@@ -1,0 +1,193 @@
+"""
+Go through each merged PR with a "needs backport to 3.x" label and check
+if there is a commit on the corresponding branch that refers to that PR.
+
+Some PRs have those labels but:
+
+* the backport was manually done and the label is still there, or
+* the backport is missing and was forgotten about, or
+* the backport was deliberately held up
+"""
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "ghapi",
+#     "rich",
+# ]
+# ///
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+from collections import defaultdict
+from functools import cache
+from typing import Any, TypeAlias
+
+from ghapi.all import GhApi, paged  # pip install ghapi
+from rich import print  # pip install rich
+
+from potential_closeable_prs import sort_by_to_sort_and_direction
+
+PR: TypeAlias = dict[str, Any]
+
+
+GITHUB_TOKEN = os.environ["GITHUB_TOOLS_TOKEN"]
+
+
+@cache
+def get_pr_commit(pull_number: int) -> str:
+    return api.pulls.get(pull_number=pull_number).merge_commit_sha
+
+
+@cache
+def get_title_of_commit(repo_path: str, commit_sha: str) -> str:
+    return (
+        subprocess.check_output(
+            ["git", "log", "-1", "--pretty=%B", commit_sha], cwd=repo_path
+        )
+        .decode("utf-8")
+        .split("\n")[0]
+    )
+
+
+@cache
+def is_commit_title_in_branch(repo_path: str, title: str, branch: str) -> bool:
+    # TODO make sure title is escaped for grep
+    output = subprocess.check_output(
+        ["git", "log", "--grep", title, branch], cwd=repo_path
+    ).decode("utf-8")
+    return output != ""
+
+
+def check_prs(
+    repo_path: str,
+    branch_to_check: str,
+    start: int = 1,
+    number: int = 100,
+    sort_by: str = "newest",
+) -> dict[str, list[PR]]:
+    sort, direction = sort_by_to_sort_and_direction(sort_by)
+    candidates = defaultdict(list)  # reason => PRs
+    pr_count = 0
+    for page in paged(
+        # The PR API doesn't filter by label.
+        # PR are really issues, so use the issues API.
+        api.issues.list_for_repo,
+        state="closed",
+        sort=sort,
+        direction=direction,
+        per_page=100,
+        labels=f"needs backport to {branch_to_check}",
+    ):
+        for pr in page:
+            pr_count += 1
+            print(pr_count, start, number, pr.html_url)
+
+            if pr_count < start:
+                continue
+
+            if pr_count >= start + number:
+                return candidates
+
+            if "/issues/" in pr.html_url:
+                print("    [red]Issue with backport labels[/red]")
+                candidates["issues with backport labels"].append(pr)
+                continue
+
+            if not pr.pull_request.merged_at:
+                # PR was closed without being merged, skip it
+                continue
+            commit = get_pr_commit(pr.number)
+            title = get_title_of_commit(repo_path, commit)
+            print(f"  {title}")
+
+            if is_commit_title_in_branch(repo_path, title, branch_to_check):
+                print("    [red]Backport found, remove label?[/red]")
+                candidates["with backports, remove label?"].append(pr)
+            else:
+                print(f"    [yellow]Backport to {branch_to_check} missing[/yellow]")
+                candidates["missing backports"].append(pr)
+
+    return candidates
+
+
+def main(args) -> None:
+    # Find
+    total_candidates = defaultdict(list)
+    for branch in args.branches.split(","):
+        print(f"\nChecking branch {branch}")
+        candidates = check_prs(
+            args.repo_path, branch, args.start, args.number, args.sort
+        )
+        for reason, prs in candidates.items():
+            total_candidates[reason].extend(prs)
+
+    # Report
+    def report(prs: list[PR]):
+        if prs:
+            seen = set()
+            cmd = "open "
+            for pr in prs:
+                if pr["number"] in seen:
+                    continue
+                print(f'\\[#{pr["number"]}]({pr["html_url"]}) {pr["title"]}')
+                cmd += f"{pr['html_url']} "
+                seen.add(pr["number"])
+            print()
+            print(cmd)
+            if args.open_prs:
+                os.system(cmd)
+
+    print("\n[bold]Results[/bold]")
+    for reason, prs in total_candidates.items():
+        total = len({pr["number"] for pr in prs})
+        print(f"\nFound {total} {reason}")
+        report(prs)
+
+    print("\n[bold]Summary[/bold]\n")
+    for reason, prs in total_candidates.items():
+        total = len({pr["number"] for pr in prs})
+        print(f"* Found {total} {reason}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("repo_path", help="path to CPython repo")
+    parser.add_argument(
+        "-b",
+        "--branches",
+        default="3.13,3.12,3.11,3.10,3.9,3.8",
+        help="branches to check",
+    )
+    parser.add_argument(
+        "-s", "--start", default=1, type=int, help="start at this PR number"
+    )
+    parser.add_argument(
+        "-n", "--number", default=100, type=int, help="number of PRs to check"
+    )
+    parser.add_argument(
+        "--sort",
+        default="newest",
+        choices=(
+            "newest",
+            "oldest",
+            "most-commented",
+            "least-commented",
+            "recently-updated",
+            "least-recently-updated",
+        ),
+        help="Sort by",
+    )
+    parser.add_argument(
+        "-o", "--open-prs", action="store_true", help="open PRs in browser"
+    )
+    args = parser.parse_args()
+
+    api = GhApi(owner="python", repo="cpython", token=GITHUB_TOKEN)
+    main(args)


### PR DESCRIPTION
Go through each merged PR with a "needs backport to 3.x" label and check if there is a commit on the corresponding branch that refers to that PR.

Some PRs have those labels but:

* the backport was manually done and the label is still there, or
* the backport is missing and was forgotten about, or
* the backport was deliberately held up

Run like `p needs_backport.py ../python/cpython/main --branches 3.13,3.12`

Sample output:

```
❯ python3 needs_backport.py /Users/hugo/github/python/cpython/main -b 3.13,3.12,3.11

Checking branch 3.13
1 1 100 https://github.com/python/cpython/pull/123885
  Small improvements to the itertools docs (GH-123885)
    Backport to 3.13 missing
2 1 100 https://github.com/python/cpython/pull/123844
3 1 100 https://github.com/python/cpython/pull/123825
4 1 100 https://github.com/python/cpython/pull/123336
  Fix typos in docs, error messages and comments (#123336)
    Backport to 3.13 missing
5 1 100 https://github.com/python/cpython/pull/123286
  gh-82378: Document the difference between sys.tracebacklimit and the limit arguments (#123286)
    Backport to 3.13 missing
6 1 100 https://github.com/python/cpython/pull/123172
7 1 100 https://github.com/python/cpython/pull/122282
8 1 100 https://github.com/python/cpython/pull/122232
9 1 100 https://github.com/python/cpython/pull/122207
  gh-122208: Don't delivery PyDict_EVENT_ADDED until it can't fail (#122207)
    Backport to 3.13 missing
10 1 100 https://github.com/python/cpython/pull/121882
11 1 100 https://github.com/python/cpython/pull/121830
12 1 100 https://github.com/python/cpython/pull/121636
13 1 100 https://github.com/python/cpython/pull/121550
14 1 100 https://github.com/python/cpython/pull/121230
15 1 100 https://github.com/python/cpython/pull/121135
  Fix phrasing in paragraphs with leading "similar" (#121135)
    Backport to 3.13 missing
16 1 100 https://github.com/python/cpython/pull/121063
17 1 100 https://github.com/python/cpython/pull/121052
18 1 100 https://github.com/python/cpython/pull/120731
  GH-119462: Enforce invariants of type versioning (GH-120731)
    Backport to 3.13 missing
19 1 100 https://github.com/python/cpython/pull/120703
  Add a link to free-threading HOWTO to the index (follow-up to GH-119366) (GH-120703)
    Backport to 3.13 missing
20 1 100 https://github.com/python/cpython/pull/120672
  gh-120198: Stop the world when setting __class__ on free-threaded build (GH-120672)
    Backport to 3.13 missing
21 1 100 https://github.com/python/cpython/pull/120540
22 1 100 https://github.com/python/cpython/pull/120534
23 1 100 https://github.com/python/cpython/pull/120290
24 1 100 https://github.com/python/cpython/pull/119818
25 1 100 https://github.com/python/cpython/pull/119703
26 1 100 https://github.com/python/cpython/pull/119611
  Withdraw most of my ownership in favor of Mark (#119611)
    Backport to 3.13 missing
27 1 100 https://github.com/python/cpython/pull/119463
28 1 100 https://github.com/python/cpython/pull/119399
29 1 100 https://github.com/python/cpython/pull/118290
30 1 100 https://github.com/python/cpython/pull/114116
31 1 100 https://github.com/python/cpython/pull/113601
  gh-113190: Reenable non-debug interned string cleanup (GH-113601)
    Backport to 3.13 missing
32 1 100 https://github.com/python/cpython/pull/113392
33 1 100 https://github.com/python/cpython/pull/109552
34 1 100 https://github.com/python/cpython/pull/105047

Checking branch 3.12
1 1 100 https://github.com/python/cpython/pull/123885
  Small improvements to the itertools docs (GH-123885)
    Backport to 3.12 missing
2 1 100 https://github.com/python/cpython/pull/123844
3 1 100 https://github.com/python/cpython/pull/123825
4 1 100 https://github.com/python/cpython/pull/123336
  Fix typos in docs, error messages and comments (#123336)
    Backport to 3.12 missing
5 1 100 https://github.com/python/cpython/pull/123172
6 1 100 https://github.com/python/cpython/pull/123062
  gh-82378 fix sys.tracebacklimit in pyrepl, approach 2 (#123062)
    Backport to 3.12 missing
7 1 100 https://github.com/python/cpython/pull/122232
8 1 100 https://github.com/python/cpython/pull/122230
  gh-122229: Add missing `Py_DECREF` in `func_get_annotation_dict` (#122230)
    Backport to 3.12 missing
9 1 100 https://github.com/python/cpython/pull/122207
  gh-122208: Don't delivery PyDict_EVENT_ADDED until it can't fail (#122207)
    Backport to 3.12 missing
10 1 100 https://github.com/python/cpython/pull/121882
11 1 100 https://github.com/python/cpython/pull/121830
12 1 100 https://github.com/python/cpython/pull/121197
  gh-121196: Document `dict.fromkeys` params as pos-only (#121197)
    Backport to 3.12 missing
13 1 100 https://github.com/python/cpython/pull/120520
  gh-113993: Allow interned strings to be mortal, and fix related issues (GH-120520)
    Backport to 3.12 missing
14 1 100 https://github.com/python/cpython/pull/120330
  gh-93691: fix too broad source locations of for statement iterators (#120330)
    Backport to 3.12 missing
15 1 100 https://github.com/python/cpython/pull/120290
16 1 100 https://github.com/python/cpython/pull/119818
17 1 100 https://github.com/python/cpython/pull/119728
  gh-119727: Add --single-process option to regrtest (#119728)
    Backport to 3.12 missing
18 1 100 https://github.com/python/cpython/pull/119626
  Misc cleanups and wording improvements for the itertools docs (gh-119626)
    Backport to 3.12 missing
19 1 100 https://github.com/python/cpython/pull/119611
  Withdraw most of my ownership in favor of Mark (#119611)
    Backport to 3.12 missing
20 1 100 https://github.com/python/cpython/pull/119529
  Misc improvement to the docs for itertools (gh-119529)
    Backport to 3.12 missing
21 1 100 https://github.com/python/cpython/pull/119463
22 1 100 https://github.com/python/cpython/pull/119399
23 1 100 https://github.com/python/cpython/pull/119366
  Update the documentation howto index page and group docs into 3 logical sections (GH-119366)
    Backport to 3.12 missing
24 1 100 https://github.com/python/cpython/pull/118489
  GH-118447: Fix handling of unreadable symlinks in `os.path.realpath()` (#118489)
    Backport to 3.12 missing
25 1 100 https://github.com/python/cpython/pull/118429
  gh-118422: Fix run_fileexflags() test (#118429)
    Backport to 3.12 missing
26 1 100 https://github.com/python/cpython/pull/118277
  gh-118272: Clear generator frame's locals when the generator is closed (#118277)
    Backport to 3.12 missing
27 1 100 https://github.com/python/cpython/pull/117847
  fix formatting of literal in docstring of int.from_bytes and int.to_bytes (#117847)
    Backport to 3.12 missing
28 1 100 https://github.com/python/cpython/pull/117796
29 1 100 https://github.com/python/cpython/pull/117781
  gh-117613: Argument Clinic: ensure that 'defining_class' params are positional-only (#117781)
    Backport to 3.12 missing
30 1 100 https://github.com/python/cpython/pull/117664
  gh-117663: [Enum] fix _simple_enum's detection of aliases (GH-117664)
    Backport to 3.12 missing
31 1 100 https://github.com/python/cpython/pull/117574
  gh-115142: Skip ``test_capi/test_opt.py`` if ``_testinternalcapi`` is not available (GH-117574)
    Backport to 3.12 missing
32 1 100 https://github.com/python/cpython/pull/117554
  gh-116303: Don't build xxlimited and xxlimited_35 if --disable-test-modules is given (#117554)
    Backport to 3.12 missing
33 1 100 https://github.com/python/cpython/pull/116507
  gh-115142: Skip ``test__xxsubinterpreters`` if ``_testinternalcapi`` is not available (#116507)
    Backport to 3.12 missing
34 1 100 https://github.com/python/cpython/pull/116482
  gh-116303: Handle disabled test modules in test.support helpers (#116482)
    Backport to 3.12 missing
35 1 100 https://github.com/python/cpython/pull/116456
36 1 100 https://github.com/python/cpython/pull/116421
  gh-116401: Fix blocking os.fwalk() and shutil.rmtree() on opening a named pipe (GH-116421)
    Backport found, remove label?
37 1 100 https://github.com/python/cpython/pull/116307
38 1 100 https://github.com/python/cpython/pull/116085
39 1 100 https://github.com/python/cpython/pull/115043
  gh-109991: Update Windows build to use OpenSSL 3.0.13 (#115043)
    Backport to 3.12 missing
40 1 100 https://github.com/python/cpython/pull/114780
  gh-89039: Call subclass constructors in datetime.*.replace (GH-114780)
    Backport to 3.12 missing
41 1 100 https://github.com/python/cpython/pull/114764
42 1 100 https://github.com/python/cpython/pull/114608
  Fix `c-api/file.rst` indexes (GH-114608)
    Backport to 3.12 missing
43 1 100 https://github.com/python/cpython/pull/114597
44 1 100 https://github.com/python/cpython/pull/114344
45 1 100 https://github.com/python/cpython/pull/114280
46 1 100 https://github.com/python/cpython/pull/114248
47 1 100 https://github.com/python/cpython/pull/114116
48 1 100 https://github.com/python/cpython/pull/114020
49 1 100 https://github.com/python/cpython/pull/113981
50 1 100 https://github.com/python/cpython/pull/113944
  GH-113655: Lower the C recursion limit on various platforms (GH-113944)
    Backport to 3.12 missing
51 1 100 https://github.com/python/cpython/pull/113801
  gh-113238: add Anchor to importlib.resources (#113801)
    Backport to 3.12 missing
52 1 100 https://github.com/python/cpython/pull/113771
53 1 100 https://github.com/python/cpython/pull/113724
54 1 100 https://github.com/python/cpython/pull/113668
55 1 100 https://github.com/python/cpython/pull/113601
  gh-113190: Reenable non-debug interned string cleanup (GH-113601)
    Backport to 3.12 missing
56 1 100 https://github.com/python/cpython/pull/113558
  gh-89811: Check for valid tp_version_tag in specializer (GH-113558)
    Backport to 3.12 missing
57 1 100 https://github.com/python/cpython/pull/113494
58 1 100 https://github.com/python/cpython/pull/113424
59 1 100 https://github.com/python/cpython/pull/113392
60 1 100 https://github.com/python/cpython/pull/113357
61 1 100 https://github.com/python/cpython/pull/113282
62 1 100 https://github.com/python/cpython/pull/113179
  GH-113171: Fix "private" (non-global) IP address ranges (GH-113179)
    Backport found, remove label?
63 1 100 https://github.com/python/cpython/pull/112926
64 1 100 https://github.com/python/cpython/pull/112759
  Minor stylistic edit to the grouper recipe (gh112759)
    Backport to 3.12 missing
65 1 100 https://github.com/python/cpython/pull/112514
  gh-112328: [Enum] Make some private attributes public. (GH-112514)
    Backport to 3.12 missing
66 1 100 https://github.com/python/cpython/pull/112508
  gh-112507: Detect Cygwin and MSYS with `uname` instead of `$OSTYPE` (GH-112508)
    Backport to 3.12 missing
67 1 100 https://github.com/python/cpython/pull/112104
68 1 100 https://github.com/python/cpython/pull/111582
69 1 100 https://github.com/python/cpython/pull/111232
  gh-111230: Fix errors checking in _ssl module init (#111232)
    Backport to 3.12 missing
70 1 100 https://github.com/python/cpython/pull/110868
  gh-110864: Fix _PyArg_UnpackKeywordsWithVararg overwriting vararg with NULL (#110868)
    Backport to 3.12 missing
71 1 100 https://github.com/python/cpython/pull/110790
72 1 100 https://github.com/python/cpython/pull/110653
73 1 100 https://github.com/python/cpython/pull/110458
74 1 100 https://github.com/python/cpython/pull/110448
75 1 100 https://github.com/python/cpython/pull/110374
76 1 100 https://github.com/python/cpython/pull/110362
  CI: Make macOS Intel required to succeed (GH-110362)
    Backport to 3.12 missing
77 1 100 https://github.com/python/cpython/pull/110125
  gh-107888: Fix test_mmap PROT_EXEC comment (#110125)
    Backport to 3.12 missing
78 1 100 https://github.com/python/cpython/pull/109968
  gh-109961: Docs: Fix incorrect rendering of `__replace__` in `copy.rst` (#109968)
    Backport to 3.12 missing
79 1 100 https://github.com/python/cpython/pull/109953
80 1 100 https://github.com/python/cpython/pull/109620
81 1 100 https://github.com/python/cpython/pull/109576
82 1 100 https://github.com/python/cpython/pull/109552
83 1 100 https://github.com/python/cpython/pull/109513
  gh-108303: Fix and move `badsyntax_pep3120.py` (#109513)
    Backport to 3.12 missing
84 1 100 https://github.com/python/cpython/pull/109512
  gh-108303: Move all math files to `Lib/test/mathdata/` (#109512)
    Backport to 3.12 missing
85 1 100 https://github.com/python/cpython/pull/109257
  gh-109216: Fix possible memory leak in `BUILD_MAP` (#109257)
    Backport to 3.12 missing
86 1 100 https://github.com/python/cpython/pull/109080
87 1 100 https://github.com/python/cpython/pull/108787
  gh-108777: Split _PyTime tests from _testinternalcapi.c (gh-108787)
    Backport to 3.12 missing
88 1 100 https://github.com/python/cpython/pull/108742
89 1 100 https://github.com/python/cpython/pull/108710
90 1 100 https://github.com/python/cpython/pull/108683
91 1 100 https://github.com/python/cpython/pull/108241
92 1 100 https://github.com/python/cpython/pull/108192
93 1 100 https://github.com/python/cpython/pull/108026
94 1 100 https://github.com/python/cpython/pull/107958
95 1 100 https://github.com/python/cpython/pull/107899
96 1 100 https://github.com/python/cpython/pull/107644
  gh-99437: runpy: decode path-like objects before setting globals
    Backport found, remove label?
97 1 100 https://github.com/python/cpython/pull/107542
  gh-107526: Revert "gh-100357: Convert several functions in bltinsmodule to AC" (#107542)
    Backport to 3.12 missing
98 1 100 https://github.com/python/cpython/pull/107423
99 1 100 https://github.com/python/cpython/pull/107323
100 1 100 https://github.com/python/cpython/pull/107216
101 1 100 https://github.com/python/cpython/pull/107063

Checking branch 3.11
1 1 100 https://github.com/python/cpython/pull/120825
  [3.12] gh-120384: Fix array-out-of-bounds crash in `list_ass_subscript` (GH-120442) (#120825)
    Backport to 3.11 missing
2 1 100 https://github.com/python/cpython/pull/116942
  gh-56374: Clarify documentation of nonlocal (#116942)
    Backport to 3.11 missing
3 1 100 https://github.com/python/cpython/pull/116788
  gh-116780: Fix `test_inspect` in `-OO` mode (#116788)
    Backport to 3.11 missing
4 1 100 https://github.com/python/cpython/pull/116482
  gh-116303: Handle disabled test modules in test.support helpers (#116482)
    Backport to 3.11 missing
5 1 100 https://github.com/python/cpython/pull/116307
6 1 100 https://github.com/python/cpython/pull/116298
  gh-115664: Fix ordering of more versionadded and versionchanged directives (GH-116298)
    Backport found, remove label?
7 1 100 https://github.com/python/cpython/pull/116085
8 1 100 https://github.com/python/cpython/pull/115853
  gh-90300: Improve the Python CLI help output (GH-115853)
    Backport found, remove label?
9 1 100 https://github.com/python/cpython/pull/115495
  GH-113516: don't set `LDSHARED` when building for WASI (GH-115495)
    Backport found, remove label?
10 1 100 https://github.com/python/cpython/pull/115325
  gh-115233: Fix an example in the Logging Cookbook (GH-115325)
    Backport found, remove label?
11 1 100 https://github.com/python/cpython/pull/115043
  gh-109991: Update Windows build to use OpenSSL 3.0.13 (#115043)
    Backport to 3.11 missing
12 1 100 https://github.com/python/cpython/pull/114780
  gh-89039: Call subclass constructors in datetime.*.replace (GH-114780)
    Backport to 3.11 missing
13 1 100 https://github.com/python/cpython/pull/114597
14 1 100 https://github.com/python/cpython/pull/114344
15 1 100 https://github.com/python/cpython/pull/114343
  gh-108303: Move `.whl` test files to `Lib/test/wheeldata/` (#114343)
    Backport to 3.11 missing
16 1 100 https://github.com/python/cpython/pull/114280
17 1 100 https://github.com/python/cpython/pull/114248
18 1 100 https://github.com/python/cpython/pull/114020
19 1 100 https://github.com/python/cpython/pull/113771
20 1 100 https://github.com/python/cpython/pull/113724
21 1 100 https://github.com/python/cpython/pull/113558
  gh-89811: Check for valid tp_version_tag in specializer (GH-113558)
    Backport found, remove label?
22 1 100 https://github.com/python/cpython/pull/113494
23 1 100 https://github.com/python/cpython/pull/113424
24 1 100 https://github.com/python/cpython/pull/113357
25 1 100 https://github.com/python/cpython/pull/113282
26 1 100 https://github.com/python/cpython/pull/113179
  GH-113171: Fix "private" (non-global) IP address ranges (GH-113179)
    Backport to 3.11 missing
27 1 100 https://github.com/python/cpython/pull/113035
  gh-106905: Use separate structs to track recursion depth in each PyAST_mod2obj call. (GH-113035)
    Backport found, remove label?
28 1 100 https://github.com/python/cpython/pull/113033
  gh-86179: Implement realpath() on Windows for getpath.py calculations (GH-113033)
    Backport to 3.11 missing
29 1 100 https://github.com/python/cpython/pull/112926
30 1 100 https://github.com/python/cpython/pull/112921
  gh-112919: Speed-up datetime, date and time.replace() (GH-112921)
    Backport to 3.11 missing
31 1 100 https://github.com/python/cpython/pull/112508
  gh-112507: Detect Cygwin and MSYS with `uname` instead of `$OSTYPE` (GH-112508)
    Backport to 3.11 missing
32 1 100 https://github.com/python/cpython/pull/111930
  gh-102837: more tests for the math module (GH-111930)
    Backport found, remove label?
33 1 100 https://github.com/python/cpython/pull/111601
  GH-110894: Call loop exception handler for exceptions in client_connected_cb (#111601)
    Backport to 3.11 missing
34 1 100 https://github.com/python/cpython/pull/111296
  gh-111295: Fix error checking in time extension module init (#111296)
    Backport to 3.11 missing
35 1 100 https://github.com/python/cpython/pull/111254
  gh-111253: Fix error checking in _socket module init (#111254)
    Backport to 3.11 missing
36 1 100 https://github.com/python/cpython/pull/111232
  gh-111230: Fix errors checking in _ssl module init (#111232)
    Backport to 3.11 missing
37 1 100 https://github.com/python/cpython/pull/110790
38 1 100 https://github.com/python/cpython/pull/110732
  [3.12] gh-108303: Move all inspect test files to `test_inspect/` (GH-109607) (#110732)
    Backport to 3.11 missing
39 1 100 https://github.com/python/cpython/pull/110458
40 1 100 https://github.com/python/cpython/pull/110448
41 1 100 https://github.com/python/cpython/pull/110374
42 1 100 https://github.com/python/cpython/pull/110362
  CI: Make macOS Intel required to succeed (GH-110362)
    Backport to 3.11 missing
43 1 100 https://github.com/python/cpython/pull/110336
  gh-110335: asyncio test_unix_events cleans multiprocessing (#110336)
    Backport to 3.11 missing
44 1 100 https://github.com/python/cpython/pull/110002
  gh-109991: Update GitHub CI workflows to use OpenSSL 3.0.11 and multissltests to use 1.1.1w, 3.0.11, and 3.1.3. (gh-110002)
    Backport to 3.11 missing
45 1 100 https://github.com/python/cpython/pull/109968
  gh-109961: Docs: Fix incorrect rendering of `__replace__` in `copy.rst` (#109968)
    Backport to 3.11 missing
46 1 100 https://github.com/python/cpython/pull/109953
47 1 100 https://github.com/python/cpython/pull/109745
  More informative docstrings in the random module (gh-109745)
    Backport to 3.11 missing
48 1 100 https://github.com/python/cpython/pull/109620
49 1 100 https://github.com/python/cpython/pull/109576
50 1 100 https://github.com/python/cpython/pull/109512
  gh-108303: Move all math files to `Lib/test/mathdata/` (#109512)
    Backport to 3.11 missing
51 1 100 https://github.com/python/cpython/pull/109257
  gh-109216: Fix possible memory leak in `BUILD_MAP` (#109257)
    Backport to 3.11 missing
52 1 100 https://github.com/python/cpython/pull/108966
  [3.12] gh-108834: Sync libregrtest with the main branch (#108966)
    Backport to 3.11 missing
53 1 100 https://github.com/python/cpython/pull/108683
54 1 100 https://github.com/python/cpython/pull/108256
  gh-108179: Add error message for parser stack overflows (#108256)
    Backport to 3.11 missing
55 1 100 https://github.com/python/cpython/pull/108242
  gh-107901: Fix missing line number on BACKWARD_JUMP at the end of a for loop (#108242)
    Backport to 3.11 missing
56 1 100 https://github.com/python/cpython/pull/108192
57 1 100 https://github.com/python/cpython/pull/107986
  gh-105857: Document that asyncio subprocess std{in,out,err} can be file handles (#107986)
    Backport to 3.11 missing
58 1 100 https://github.com/python/cpython/pull/107958
59 1 100 https://github.com/python/cpython/pull/107899
60 1 100 https://github.com/python/cpython/pull/107423
61 1 100 https://github.com/python/cpython/pull/107323
62 1 100 https://github.com/python/cpython/pull/107067
  Remove superflous whitespaces in `layout.html`. (GH-107067)
    Backport to 3.11 missing
63 1 100 https://github.com/python/cpython/pull/107063
64 1 100 https://github.com/python/cpython/pull/106995
  gh-102111: Add link to string escape sequences in re module (#106995)
    Backport to 3.11 missing
65 1 100 https://github.com/python/cpython/pull/106926
66 1 100 https://github.com/python/cpython/pull/106813
67 1 100 https://github.com/python/cpython/pull/106671
  gh-106634: Corrected minor asyncio doc issues (#106671)
    Backport to 3.11 missing
68 1 100 https://github.com/python/cpython/pull/106026
69 1 100 https://github.com/python/cpython/pull/105962
70 1 100 https://github.com/python/cpython/pull/105827
71 1 100 https://github.com/python/cpython/pull/105403
  sliding_window() recipe:  Raise ValueError for non-positive window sizes.  Add more tests. (GH-105403)
    Backport to 3.11 missing
72 1 100 https://github.com/python/cpython/pull/105361
73 1 100 https://github.com/python/cpython/pull/105345
  gh-102304: doc: Add links to Stable ABI and Limited C API (#105345)
    Backport to 3.11 missing
74 1 100 https://github.com/python/cpython/pull/105127
  gh-102988: Detect email address parsing errors and return empty tuple to indicate the parsing error (old API) (#105127)
    Backport to 3.11 missing
75 1 100 https://github.com/python/cpython/pull/104969
  Fix inaccuracies in "Assorted Topics" section of "Defining Extension Types" tutorial (#104969)
    Backport to 3.11 missing
76 1 100 https://github.com/python/cpython/pull/104934
  Improves the Windows MSI test run on PR (GH-104929)
    Backport to 3.11 missing
77 1 100 https://github.com/python/cpython/pull/104929
  Improves the Windows MSI test run on PR (GH-104929)
    Backport to 3.11 missing
78 1 100 https://github.com/python/cpython/pull/104846
  gh-104825: Remove implicit newline in the line attribute in tokens emitted in the tokenize module (#104846)
    Backport to 3.11 missing
79 1 100 https://github.com/python/cpython/pull/104579
  GH-102818: Do not call `PyTraceBack_Here` in sys.settrace trampoline.  (GH-104579)
    Backport to 3.11 missing
80 1 100 https://github.com/python/cpython/pull/104483
  gh-104482: Fix error handling bugs in ast.c (#104483)
    Backport to 3.11 missing
81 1 100 https://github.com/python/cpython/pull/104379
82 1 100 https://github.com/python/cpython/pull/104326
  gh-74895: adjust tests to work on Solaris (#104326)
    Backport to 3.11 missing
83 1 100 https://github.com/python/cpython/issues/103935
    Issue with backport labels
84 1 100 https://github.com/python/cpython/pull/103923
  Various small fixes to dis docs (#103923)
    Backport to 3.11 missing
85 1 100 https://github.com/python/cpython/issues/103883
    Issue with backport labels
86 1 100 https://github.com/python/cpython/pull/103838
  gh-103721: Improve cross-references for generic-alias docs (#103838)
    Backport to 3.11 missing
87 1 100 https://github.com/python/cpython/pull/103836
  GH-69695: Update ``PyImport_ImportModule`` description (GH-103836)
    Backport found, remove label?
88 1 100 https://github.com/python/cpython/pull/103782
  gh-103780: Use patch instead of mock in asyncio unix events test (#103782)
    Backport to 3.11 missing
89 1 100 https://github.com/python/cpython/pull/103392
90 1 100 https://github.com/python/cpython/pull/103173
91 1 100 https://github.com/python/cpython/pull/103047
  gh-103046: Display current line correctly for `dis.disco()` with CACHE entries (#103047)
    Backport to 3.11 missing
92 1 100 https://github.com/python/cpython/pull/103009
  GH-102833: Mention the key function in the docstrings (GH-103009)
    Backport to 3.11 missing
93 1 100 https://github.com/python/cpython/pull/102966
94 1 100 https://github.com/python/cpython/pull/102712
  GH-102711: Fix warnings found by clang (#102712)
    Backport to 3.11 missing
95 1 100 https://github.com/python/cpython/pull/102597
96 1 100 https://github.com/python/cpython/issues/102549
    Issue with backport labels
97 1 100 https://github.com/python/cpython/pull/102448
  fix typo in async generator code field name `ag_code` (#102448)
    Backport to 3.11 missing
98 1 100 https://github.com/python/cpython/pull/102328
  gh-102327: Extend docs for "url" and "headers" parameters to HTTPConnection.request()
    Backport found, remove label?
99 1 100 https://github.com/python/cpython/pull/102313
100 1 100 https://github.com/python/cpython/pull/102217
  gh-102215: importlib documentation cleanups
    Backport found, remove label?
101 1 100 https://github.com/python/cpython/pull/102208
```
```
Results

Found 86 missing backports
[#123885](https://github.com/python/cpython/pull/123885) Small improvements to the itertools docs
[#123336](https://github.com/python/cpython/pull/123336) Fix typos in docs, error messages and comments
[#123286](https://github.com/python/cpython/pull/123286) gh-82378: document the difference between sys.tracebacklimit and the limit arguments
[#122207](https://github.com/python/cpython/pull/122207) gh-122208: Don't delivery PyDict_EVENT_ADDED until it can't fail
[#121135](https://github.com/python/cpython/pull/121135) Paragraphs with leading similar
[#120731](https://github.com/python/cpython/pull/120731) GH-119462: Enforce invariants of type versioning
[#120703](https://github.com/python/cpython/pull/120703) Add a link to free-threading HOWTO to the index (follow-up to GH-119366)
[#120672](https://github.com/python/cpython/pull/120672) gh-120198: Stop the world when setting __class__ on free-threaded build
[#119611](https://github.com/python/cpython/pull/119611) Withdraw most of my ownership in favor of Mark
[#113601](https://github.com/python/cpython/pull/113601) gh-113190: Reenable non-debug interned string cleanup
[#123062](https://github.com/python/cpython/pull/123062) gh-82378 fix sys.tracebacklimit in pyrepl
[#122230](https://github.com/python/cpython/pull/122230) gh-122229: Add missing `Py_DECREF` in `func_get_annotation_dict`
[#121197](https://github.com/python/cpython/pull/121197) gh-121196: Document `dict.fromkeys` params as pos-only
[#120520](https://github.com/python/cpython/pull/120520) gh-113993: Allow interned strings to be mortal, and fix related issues
[#120330](https://github.com/python/cpython/pull/120330) gh-93691: fix too broad source locations of for statement iterators
[#119728](https://github.com/python/cpython/pull/119728) gh-119727: Add --single-process option to regrtest
[#119626](https://github.com/python/cpython/pull/119626) Misc cleanups and wording improvements for the itertools docs
[#119529](https://github.com/python/cpython/pull/119529) Misc improvement to the docs for itertools
[#119366](https://github.com/python/cpython/pull/119366) Update the documentation howto index page and group docs into 3 logical sections
[#118489](https://github.com/python/cpython/pull/118489) GH-118447: Fix handling of unreadable symlinks in `os.path.realpath()`
[#118429](https://github.com/python/cpython/pull/118429) gh-118422: Fix run_fileexflags() test
[#118277](https://github.com/python/cpython/pull/118277) gh-118272: Clear generator frame's locals when the generator is closed
[#117847](https://github.com/python/cpython/pull/117847) fix formatting of literal in docstring of int.from_bytes and int.to_bytes
[#117781](https://github.com/python/cpython/pull/117781) gh-117613: Argument Clinic: ensure that `defining_class` params are positional-only
[#117664](https://github.com/python/cpython/pull/117664) gh-117663: [Enum] fix _simple_enum's detection of aliases
[#117574](https://github.com/python/cpython/pull/117574) gh-115142: Skip ``test_capi/test_opt.py`` if ``_testinternalcapi`` is not available
[#117554](https://github.com/python/cpython/pull/117554) gh-116303: Don't build xxlimited and xxlimited_35 if --disable-test-modules is given
[#116507](https://github.com/python/cpython/pull/116507) gh-115142: Skip ``test__xxsubinterpreters`` if ``_testinternalcapi`` is not available
[#116482](https://github.com/python/cpython/pull/116482) gh-116303: Handle disabled test modules in test.support
[#115043](https://github.com/python/cpython/pull/115043) gh-109991: Update Windows build to use OpenSSL 3.0.13
[#114780](https://github.com/python/cpython/pull/114780) gh-89039: call subclass constructors in datetime.*.replace
[#114608](https://github.com/python/cpython/pull/114608) Fix `c-api/file.rst` indexes
[#113944](https://github.com/python/cpython/pull/113944) GH-113655: Lower the C recursion limit on various platforms
[#113801](https://github.com/python/cpython/pull/113801) gh-113238: add Anchor to importlib.resources
[#113558](https://github.com/python/cpython/pull/113558) gh-89811: Check for valid tp_version_tag in specializer
[#112759](https://github.com/python/cpython/pull/112759) Check argument in itertools's recipe for "grouper"
[#112514](https://github.com/python/cpython/pull/112514) gh-112328: [Enum] Make some private attributes public.
[#112508](https://github.com/python/cpython/pull/112508) gh-112507 Detect Cygwin and MSYS with `uname` instead of `$OSTYPE`
[#111232](https://github.com/python/cpython/pull/111232) gh-111230: Fix `_ssl.c` not checking for errors when initializing a module
[#110868](https://github.com/python/cpython/pull/110868) gh-110864: Fix `_PyArg_UnpackKeywordsWithVararg` overwriting `vararg` with `NULL`
[#110362](https://github.com/python/cpython/pull/110362) CI: Make macOS Intel required to succeed
[#110125](https://github.com/python/cpython/pull/110125) gh-107888: Fix test_mmap PROT_EXEC comment
[#109968](https://github.com/python/cpython/pull/109968) gh-109961: Docs: Fix incorrect rendering of `__replace__` in `copy.rst`
[#109513](https://github.com/python/cpython/pull/109513) gh-108303: Fix and move `badsyntax_pep3120.py`
[#109512](https://github.com/python/cpython/pull/109512) gh-108303: Move all math files to `Lib/test/mathdata/`
[#109257](https://github.com/python/cpython/pull/109257) gh-109216: Fix possible memory leak in `BUILD_MAP`
[#108787](https://github.com/python/cpython/pull/108787) gh-108777: Split _PyTime tests from _testinternalcapi.c
[#107542](https://github.com/python/cpython/pull/107542) gh-107526: Revert "gh-100357: Convert several functions in bltinsmodule to AC"
[#120825](https://github.com/python/cpython/pull/120825) [3.12] gh-120384: Fix array-out-of-bounds crash in `list_ass_subscript` (GH-120442)
[#116942](https://github.com/python/cpython/pull/116942) gh-56374: Clarify documentation of nonlocal
[#116788](https://github.com/python/cpython/pull/116788) gh-116780: Fix `test_inspect` in `-OO` mode
[#114343](https://github.com/python/cpython/pull/114343) gh-108303: Move `.whl` test files to `Lib/test/whldata/`
[#113179](https://github.com/python/cpython/pull/113179) GH-113171: Fix "private" (non-global) IP address ranges
[#113033](https://github.com/python/cpython/pull/113033) gh-86179: Implement realpath() on Windows during getpath.py calculations
[#112921](https://github.com/python/cpython/pull/112921) gh-112919: Speed-up datetime, date and time.replace()
[#111601](https://github.com/python/cpython/pull/111601) GH-110894: Call loop exception handler for exceptions in client_connected_cb
[#111296](https://github.com/python/cpython/pull/111296) gh-111295: Fix timemodule.c not checking for errors when initializing
[#111254](https://github.com/python/cpython/pull/111254) gh-111253: Fix socketmodule.c not checking for errors when initializing
[#110732](https://github.com/python/cpython/pull/110732) [3.12] gh-108303: Move all inspect test files to `test_inspect/` (GH-109607)
[#110336](https://github.com/python/cpython/pull/110336) gh-110335: asyncio test_unix_events cleans multiprocessing
[#110002](https://github.com/python/cpython/pull/110002) gh-109991: Update GitHub CI workflows to use OpenSSL 3.0.11 and multissltests to use 1.1.1w, 3.0.11,
and 3.1.3.
[#109745](https://github.com/python/cpython/pull/109745) More informative docstrings in the random module
[#108966](https://github.com/python/cpython/pull/108966) [3.12] gh-108834: Sync libregrtest with the main branch
[#108256](https://github.com/python/cpython/pull/108256) gh-108179: Add error message for parser stack overflows
[#108242](https://github.com/python/cpython/pull/108242) gh-107901: Fix missing line number on BACKWARD_JUMP at the end of a for loop
[#107986](https://github.com/python/cpython/pull/107986) gh-105857: Document that asyncio subprocess std{in,out,err} can be file handles
[#107067](https://github.com/python/cpython/pull/107067) Remove superflous whitespaces in `layout.html`.
[#106995](https://github.com/python/cpython/pull/106995) gh-102111: Add link to string escape sequences in re module
[#106671](https://github.com/python/cpython/pull/106671) gh-106634: Corrected minor asyncio doc issues
[#105403](https://github.com/python/cpython/pull/105403) sliding_window() recipe:  Raise ValueError for non-positive window sizes.  Add more tests.
[#105345](https://github.com/python/cpython/pull/105345) gh-102304: doc: Add links to Stable ABI and Limited C API
[#105127](https://github.com/python/cpython/pull/105127) gh-102988: Detect email address parsing errors and return empty tuple to indicate the parsing error
(old API)
[#104969](https://github.com/python/cpython/pull/104969) Fix inaccuracies in "Assorted Topics" section of "Defining Extension Types" tutorial
[#104934](https://github.com/python/cpython/pull/104934) [3.12] Improves the Windows MSI test run on PR (GH-104929)
[#104929](https://github.com/python/cpython/pull/104929) Build docs as part of the MSI test
[#104846](https://github.com/python/cpython/pull/104846) gh-104825: Remove implicit newline in the line attribute in tokens emitted in the tokenize module
[#104579](https://github.com/python/cpython/pull/104579) GH-102818: Do not call `PyTraceBack_Here` in sys.settrace trampoline.
[#104483](https://github.com/python/cpython/pull/104483) gh-104482: Fix error handling bugs in ast.c
[#104326](https://github.com/python/cpython/pull/104326) gh-74895: adjust tests to work on Solaris
[#103923](https://github.com/python/cpython/pull/103923) Various small fixes to dis docs
[#103838](https://github.com/python/cpython/pull/103838) gh-103721: Improve cross-references for generic-alias docs
[#103782](https://github.com/python/cpython/pull/103782) gh-103780: Use patch instead of mock in asyncio unix events test
[#103047](https://github.com/python/cpython/pull/103047) gh-103046: Display current line correctly for `dis.disco()` with CACHE entries
[#103009](https://github.com/python/cpython/pull/103009) GH-102833: Mention the key function in the docstrings
[#102712](https://github.com/python/cpython/pull/102712) GH-102711: Fix warnings found by clang
[#102448](https://github.com/python/cpython/pull/102448) fix typo in async generator code field name `ag_code`

open https://github.com/python/cpython/pull/123885 https://github.com/python/cpython/pull/123336 https://github.com/python/cpython/pull/123286
https://github.com/python/cpython/pull/122207 https://github.com/python/cpython/pull/121135 https://github.com/python/cpython/pull/120731
https://github.com/python/cpython/pull/120703 https://github.com/python/cpython/pull/120672 https://github.com/python/cpython/pull/119611
https://github.com/python/cpython/pull/113601 https://github.com/python/cpython/pull/123062 https://github.com/python/cpython/pull/122230
https://github.com/python/cpython/pull/121197 https://github.com/python/cpython/pull/120520 https://github.com/python/cpython/pull/120330
https://github.com/python/cpython/pull/119728 https://github.com/python/cpython/pull/119626 https://github.com/python/cpython/pull/119529
https://github.com/python/cpython/pull/119366 https://github.com/python/cpython/pull/118489 https://github.com/python/cpython/pull/118429
https://github.com/python/cpython/pull/118277 https://github.com/python/cpython/pull/117847 https://github.com/python/cpython/pull/117781
https://github.com/python/cpython/pull/117664 https://github.com/python/cpython/pull/117574 https://github.com/python/cpython/pull/117554
https://github.com/python/cpython/pull/116507 https://github.com/python/cpython/pull/116482 https://github.com/python/cpython/pull/115043
https://github.com/python/cpython/pull/114780 https://github.com/python/cpython/pull/114608 https://github.com/python/cpython/pull/113944
https://github.com/python/cpython/pull/113801 https://github.com/python/cpython/pull/113558 https://github.com/python/cpython/pull/112759
https://github.com/python/cpython/pull/112514 https://github.com/python/cpython/pull/112508 https://github.com/python/cpython/pull/111232
https://github.com/python/cpython/pull/110868 https://github.com/python/cpython/pull/110362 https://github.com/python/cpython/pull/110125
https://github.com/python/cpython/pull/109968 https://github.com/python/cpython/pull/109513 https://github.com/python/cpython/pull/109512
https://github.com/python/cpython/pull/109257 https://github.com/python/cpython/pull/108787 https://github.com/python/cpython/pull/107542
https://github.com/python/cpython/pull/120825 https://github.com/python/cpython/pull/116942 https://github.com/python/cpython/pull/116788
https://github.com/python/cpython/pull/114343 https://github.com/python/cpython/pull/113179 https://github.com/python/cpython/pull/113033
https://github.com/python/cpython/pull/112921 https://github.com/python/cpython/pull/111601 https://github.com/python/cpython/pull/111296
https://github.com/python/cpython/pull/111254 https://github.com/python/cpython/pull/110732 https://github.com/python/cpython/pull/110336
https://github.com/python/cpython/pull/110002 https://github.com/python/cpython/pull/109745 https://github.com/python/cpython/pull/108966
https://github.com/python/cpython/pull/108256 https://github.com/python/cpython/pull/108242 https://github.com/python/cpython/pull/107986
https://github.com/python/cpython/pull/107067 https://github.com/python/cpython/pull/106995 https://github.com/python/cpython/pull/106671
https://github.com/python/cpython/pull/105403 https://github.com/python/cpython/pull/105345 https://github.com/python/cpython/pull/105127
https://github.com/python/cpython/pull/104969 https://github.com/python/cpython/pull/104934 https://github.com/python/cpython/pull/104929
https://github.com/python/cpython/pull/104846 https://github.com/python/cpython/pull/104579 https://github.com/python/cpython/pull/104483
https://github.com/python/cpython/pull/104326 https://github.com/python/cpython/pull/103923 https://github.com/python/cpython/pull/103838
https://github.com/python/cpython/pull/103782 https://github.com/python/cpython/pull/103047 https://github.com/python/cpython/pull/103009
https://github.com/python/cpython/pull/102712 https://github.com/python/cpython/pull/102448

Found 13 with backports, remove label?
[#116421](https://github.com/python/cpython/pull/116421) gh-116401: Fix blocking os.fwalk() and shutil.rmtree() on opening named pipe
[#113179](https://github.com/python/cpython/pull/113179) GH-113171: Fix "private" (non-global) IP address ranges
[#107644](https://github.com/python/cpython/pull/107644) gh-99437: runpy: decode path-like objects before setting globals
[#116298](https://github.com/python/cpython/pull/116298) gh-115664: Fix ordering of more versionadded and versionchanged directives
[#115853](https://github.com/python/cpython/pull/115853) gh-90300: Improve the Python CLI help output
[#115495](https://github.com/python/cpython/pull/115495) GH-113516: don't set `LDSHARED` when building for WASI
[#115325](https://github.com/python/cpython/pull/115325) gh-115233: Fix an example in the Logging Cookbook
[#113558](https://github.com/python/cpython/pull/113558) gh-89811: Check for valid tp_version_tag in specializer
[#113035](https://github.com/python/cpython/pull/113035) gh-106905: Use separate structs to track recursion depth in each PyAST_mod2obj call.
[#111930](https://github.com/python/cpython/pull/111930) gh-102837: more tests for the math module
[#103836](https://github.com/python/cpython/pull/103836) GH-69695: Update ``PyImport_ImportModule`` description
[#102328](https://github.com/python/cpython/pull/102328) gh-102327: Extend docs for "url" and "headers" parameters to HTTPConnection.request()
[#102217](https://github.com/python/cpython/pull/102217) gh-102215: importlib documentation cleanups

open https://github.com/python/cpython/pull/116421 https://github.com/python/cpython/pull/113179 https://github.com/python/cpython/pull/107644
https://github.com/python/cpython/pull/116298 https://github.com/python/cpython/pull/115853 https://github.com/python/cpython/pull/115495
https://github.com/python/cpython/pull/115325 https://github.com/python/cpython/pull/113558 https://github.com/python/cpython/pull/113035
https://github.com/python/cpython/pull/111930 https://github.com/python/cpython/pull/103836 https://github.com/python/cpython/pull/102328
https://github.com/python/cpython/pull/102217

Found 3 issues with backport labels
[#103935](https://github.com/python/cpython/issues/103935) trace.__main__ does not use io.open_code
[#103883](https://github.com/python/cpython/issues/103883) Python/C API "PyUnicode_FromObject" is listed in the "Deprecated " section
[#102549](https://github.com/python/cpython/issues/102549) [Enum] Exception being ignored in custom datatypes

open https://github.com/python/cpython/issues/103935 https://github.com/python/cpython/issues/103883 https://github.com/python/cpython/issues/102549
```
```
Summary

* Found 86 missing backports
* Found 13 with backports, remove label?
* Found 3 issues with backport labels
```

Takes around:
* 6m47s to run on all default 3.13-3.8 branches
* 2m38s with `--branches 3.13,3.12,3.11`
* 1m20s with `--branches 3.13,3.12`
* 15s with `--branches 3.13`
