### PR TITLE
Pin `ghapi<2`

### DIFF
--- a/issues_by_dev.py
+++ b/issues_by_dev.py
@@ -5,7 +5,7 @@ Find number of open issues/PRs in the Python org team.
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#   "ghapi",
+#   "ghapi<2",
 #   "prettytable>=3.12.0",
 #   "requests",
 #   "rich",

--- a/needs_backport.py
+++ b/needs_backport.py
@@ -12,7 +12,7 @@ Some PRs have those labels but:
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "ghapi",
+#     "ghapi<2",
 #     "rich",
 #     "stamina",
 # ]

--- a/orphaned_backports.py
+++ b/orphaned_backports.py
@@ -7,7 +7,7 @@ for merging or closing.
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "ghapi",
+#     "ghapi<2",
 #     "rich",
 #     "stamina",
 # ]

--- a/potential_closeable_issues.py
+++ b/potential_closeable_issues.py
@@ -6,7 +6,7 @@ They're candidates for closing.
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "ghapi",
+#     "ghapi<2",
 #     "rich",
 #     "stamina",
 # ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 feedparser
-ghapi
+ghapi<2
 GitPython
 hishel>=1
 httpx


### PR DESCRIPTION
[Breaking changes](https://github.com/AnswerDotAI/ghapi/blob/main/CHANGELOG.md#breaking-changes) in `ghapi` 2.0.0 [broke the dashboard](https://github.com/hugovk/dashboard/actions/runs/29385661404).